### PR TITLE
refactor: update auth0 to new angular version

### DIFF
--- a/modules/auth0/src/auth0.guard.ts
+++ b/modules/auth0/src/auth0.guard.ts
@@ -1,30 +1,38 @@
-import { Injectable } from '@angular/core';
-import { RouterStateSnapshot, CanActivate, CanLoad, CanActivateChild, ActivatedRouteSnapshot } from '@angular/router';
-import { Observable } from 'rxjs';
-import { take } from 'rxjs/operators';
-import { IDEAApiService } from '@idea-ionic/common';
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { Platform } from '@ionic/angular';
+import { IDEAApiService, IDEAStorageService } from '@idea-ionic/common';
 
 import { IDEAAuth0Service } from './auth0.service';
 
-@Injectable({ providedIn: 'root' })
-export class IDEAAuth0Guard implements CanActivate, CanLoad, CanActivateChild {
-  constructor(private auth0: IDEAAuth0Service, private api: IDEAApiService) {}
-  private setApiAuthToken(): void {
-    this.auth0.__raw.idTokenClaims$.subscribe(claims => (this.api.authToken = claims ? claims.__raw : null));
-  }
+import { environment as env } from '@env';
 
-  canLoad(): Observable<boolean> {
-    this.setApiAuthToken();
-    return this.auth0.__raw.isAuthenticated$.pipe(take(1));
-  }
+export const auth0Guard: CanActivateFn = async () => {
+  const platform = inject(Platform);
+  const storage = inject(IDEAStorageService);
+  const api = inject(IDEAApiService);
+  const auth = inject(IDEAAuth0Service);
 
-  canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
-    this.setApiAuthToken();
-    return this.auth0.redirectIfUnauthenticated(state.url);
-  }
+  //
+  // HELPERS
+  //
 
-  canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
-    this.setApiAuthToken();
-    return this.auth0.redirectIfUnauthenticated(state.url);
-  }
-}
+  const doAuth = async (): Promise<void> => {
+    auth.redirectIfUnauthenticated(env.auth0.callbackUri);
+    auth.goToLogin();
+    setApiAuthToken();
+  };
+
+  const setApiAuthToken = (): void => {
+    auth.__raw.idTokenClaims$.subscribe(claims => (api.authToken = claims ? claims.__raw : null));
+    if (!api.authToken) api.authToken = auth.getIdToken();
+  };
+
+  setApiAuthToken();
+  if (auth.isUserAuthenticated()) return true;
+
+  await platform.ready();
+  await storage.ready();
+
+  await doAuth();
+};

--- a/modules/auth0/src/auth0.guard.ts
+++ b/modules/auth0/src/auth0.guard.ts
@@ -1,13 +1,11 @@
 import { inject } from '@angular/core';
-import { CanActivateFn } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivateFn, RouterStateSnapshot } from '@angular/router';
 import { Platform } from '@ionic/angular';
 import { IDEAApiService, IDEAStorageService } from '@idea-ionic/common';
 
 import { IDEAAuth0Service } from './auth0.service';
 
-import { environment as env } from '@env';
-
-export const auth0Guard: CanActivateFn = async () => {
+export const auth0Guard: CanActivateFn = async (next: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
   const platform = inject(Platform);
   const storage = inject(IDEAStorageService);
   const api = inject(IDEAApiService);
@@ -18,9 +16,8 @@ export const auth0Guard: CanActivateFn = async () => {
   //
 
   const doAuth = async (): Promise<void> => {
-    auth.redirectIfUnauthenticated(env.auth0.callbackUri);
-    auth.goToLogin();
     setApiAuthToken();
+    auth.goToLogin(state.url);
   };
 
   const setApiAuthToken = (): void => {
@@ -35,4 +32,6 @@ export const auth0Guard: CanActivateFn = async () => {
   await storage.ready();
 
   await doAuth();
+
+  return auth.isUserAuthenticated();
 };

--- a/modules/auth0/src/auth0.module.ts
+++ b/modules/auth0/src/auth0.module.ts
@@ -13,7 +13,7 @@ import { environment as env } from '@env';
       useRefreshTokens: env.auth0.storeRefreshToken,
       cacheLocation: env.auth0.storeRefreshToken ? 'localstorage' : 'memory',
       authorizationParams: {
-        redirectUri: env.auth0.callbackUri
+        redirect_uri: env.auth0.callbackUri
       }
     })
   ],

--- a/modules/auth0/src/auth0.module.ts
+++ b/modules/auth0/src/auth0.module.ts
@@ -13,7 +13,7 @@ import { environment as env } from '@env';
       useRefreshTokens: env.auth0.storeRefreshToken,
       cacheLocation: env.auth0.storeRefreshToken ? 'localstorage' : 'memory',
       authorizationParams: {
-        redirect_uri: env.auth0.callbackUri
+        redirect_uri: env.auth0.callbackUri || window.location.origin
       }
     })
   ],

--- a/modules/auth0/src/auth0.service.ts
+++ b/modules/auth0/src/auth0.service.ts
@@ -68,23 +68,6 @@ export class IDEAAuth0Service {
   }
 
   /**
-   * Redirect to login if not authenticated.
-   * Meant to be used in a Guard; example:
-   * ```
-    canActivate(_, state: RouterStateSnapshot): Observable<boolean> {
-      return this.auth.redirectIfUnauthenticated(state.url);
-    }
-   * ```
-   */
-  redirectIfUnauthenticated(afterRedirectUrl: string): Observable<boolean> {
-    return this.auth0.isAuthenticated$.pipe(
-      tap(loggedIn => {
-        if (!loggedIn) this.goToLogin(afterRedirectUrl);
-      })
-    );
-  }
-
-  /**
    * Handle the callback after a login or logout in Auth0 Universal Login page.
    * In order to work, it has to be used in `app.component.ts`, as explained in the following snippet:
    * ```


### PR DESCRIPTION
Updates auth0 to new standard using function instead of guard.

Note: I tested this in the djv repo and made some changes which I'm not sure are needed here (since here it will be packed as a module):

In the module I removed the `providers` attribute as it was causing conflicts
In the service I changed `@Injectable()` to `@Injectable({ providedIn: 'root' })`

Note: currently in the app when I press login for a brief moment we see the available shops before we are redirected to login.